### PR TITLE
Risk score updates

### DIFF
--- a/presentations/leeds.qmd
+++ b/presentations/leeds.qmd
@@ -136,6 +136,9 @@ The IMD overall score combines information from the seven domains to produce an 
 ## IMD overall score by MSOA
 
 ```{python}
+#| label: imd-overall-location
+#| echo: false
+
 fig = plot_chloropleth("imd_overall_score_2015", merged, "Leeds", color_continuous_scale="rdylbu_r")
 fig.show()
 ```

--- a/presentations/leeds.qmd
+++ b/presentations/leeds.qmd
@@ -9,10 +9,12 @@ format:
     slideNumber: true
     auto: true
     scrollable: true
+    embed-resources: true
+    self-contained-math: true
 execute:
   enabled: true
   echo: true
-  cache: true
+  cache: false
 jupyter: lead_map
 ---
 
@@ -131,6 +133,13 @@ The IMD overall score combines information from the seven domains to produce an 
 | Barriers to housing and services        | 9.3            |
 | Living environment deprivation          | 9.3            |
 
+## IMD overall score by MSOA
+
+```{python}
+fig = plot_chloropleth("imd_overall_score_2015", merged, "Leeds", color_continuous_scale="rdylbu_r")
+fig.show()
+```
+
 # Risk factors: Housing
 
 ## Why housing
@@ -242,7 +251,7 @@ fig.show()
 #| label: high-income-location
 #| echo: false
 
-fig = plot_chloropleth("median_annual_incomeE", merged, "Leeds", color_continuous_scale="Viridis")
+fig = plot_chloropleth("median_annual_incomeE", merged, "Leeds", color_continuous_scale="rdylbu_r")
 fig.show()
 ```
 - The northern outskirts are richer than the center
@@ -267,7 +276,7 @@ uk_poverty_cum_20 = round((merged["poverty_rateE"] > 30).sum() / len(merged),1)
 fig = plot_histograms("poverty_rateE", merged, "Leeds", n_bins=30)
 fig.show()
 ```
-- Poverty rates in Leeds have a heavier tail than the UK, with ``{python} leeds_poverty_cum_20`` of MSOAs having more than 20% poverty, compared to ``{python} uk_poverty_cum_20`` in the UK.
+- Poverty rates in Leeds have a heavier tail than the UK, with `{python} leeds_poverty_cum_20` of MSOAs having more than 20% poverty, compared to `{python} uk_poverty_cum_20` in the UK.
 
 ## Location of poverty
 
@@ -422,7 +431,7 @@ fig.update_layout(title="Risk score in Leeds vs Oxford")
 fig.show()
 ```
 
-- Overall in the UK, Leeds has a (kid-count weighted) average risk score of ``{python} leeds_risk_score_mean``.
+- Overall in the UK, Leeds has a (kid-count weighted) average risk score of `{python} leeds_risk_score_mean`.
 
 # Appendix
 

--- a/presentations/leeds.qmd
+++ b/presentations/leeds.qmd
@@ -65,10 +65,14 @@ We believe that a combination of them can give a good indication of lead exposur
 #| echo: false
 #| cache: false
 
+# imports
 from plotting_functions import *
 import sys
 sys.path.append('../UK/predictors/exploration')
 from shapefile_loading import get_msoa_merged_shapefile
+
+# GLOBAL vars
+cities = ["Bristol", "Birmingham","Liverpool", "Leeds", "Nottingham", "Oxford", "Cambridge", "Manchester", "Chelsea", "Southampton", "Warwick"]
 ```
 
 ```{python}
@@ -140,6 +144,16 @@ The IMD overall score combines information from the seven domains to produce an 
 #| echo: false
 
 fig = plot_chloropleth("imd_overall_score_2015", merged, "Leeds", color_continuous_scale="rdylbu_r")
+fig.show()
+```
+
+## Average IMD of different cities
+
+```{python}
+#| label: imd-comparison
+#| echo: false
+
+fig = plot_UK_aggregate_comparison(merged, outcome_var = "imd_overall_score_2015", locations = cities)
 fig.show()
 ```
 
@@ -232,7 +246,7 @@ fig.show()
 - Residents may have fewer housing options and are likelier to live in older, potentially lead-contaminated buildings.
 
 ## Unemployment rate
-<!-- todo: fix the bug where always house prices are shown...? -->
+
 ```{python}
 #| label: unemployment-map
 #| echo: false
@@ -268,7 +282,7 @@ fig.show()
 ## Poverty rate by MSOA
 
 ```{python}
-#| label: poverty-comparison
+#| label: poverty-leeds-vs-uk-distribution
 #| cache: false
 #| echo: false
 
@@ -292,6 +306,17 @@ fig.show()
 ```
 
 - Poverty rates are highest towards the center
+
+## Poverty rate in different cities
+
+```{python}
+#| label: poverty-comparison
+#| echo: false
+
+fig = plot_UK_aggregate_comparison(merged, outcome_var = "poverty_rateE", locations = cities)
+fig.show()
+```
+
 
 # Risk factors: Education
 
@@ -353,7 +378,7 @@ We then use this 500m grid to compute two measures:
 ## Soil lead comparison by MSOAs
 
 ```{python}
-#| label: soil-lead-comparison
+#| label: soil-lead-distribution
 #| echo: false
 merged_no_soil_na = merged.dropna(subset=["soil_lead_mean"])
 fig = plot_histograms("soil_lead_mean_idw", merged_no_soil_na, location="Leeds", other_location="UK", n_bins=40)
@@ -368,6 +393,16 @@ fig.show()
 ```
 
 - compared to the overall UK distribution, Leeds has higher soil lead concentrations
+ 
+## Soil lead in different cities
+
+```{python}
+#| label: soil-lead-comparison
+#| echo: false
+
+fig = plot_UK_aggregate_comparison(merged, outcome_var = "soil_lead_mean", locations = cities)
+fig.show()
+```
 
 # Variable dependence
 
@@ -431,7 +466,7 @@ The MSOAs with the highest risk scores are located in the **north/north-eastern 
 
 merged_w_risk = compute_risk_score(merged, risk_factors_dict)
 
-fig = plot_UK_risk_comparison(merged_w_risk, locations = ["Leeds", "Nottingham", "Oxford", "Cambridge", "Manchester", "Chelsea", "Southampton"])
+fig = plot_UK_aggregate_comparison(merged_w_risk, outcome_var = "risk_score", locations = cities)
 fig.show()
 ```
 

--- a/presentations/leeds.qmd
+++ b/presentations/leeds.qmd
@@ -9,8 +9,8 @@ format:
     slideNumber: true
     auto: true
     scrollable: true
-    embed-resources: true
-    self-contained-math: true
+    # embed-resources: true
+    # self-contained-math: true
 execute:
   enabled: true
   echo: true
@@ -262,7 +262,7 @@ fig.show()
 - In order to have comparable poverty rates between different areas in the UK, we consider the poverty rate after adjusting for housing costs.
 - This is reported at the MSOA level.
 
-## Poverty rate
+## Poverty rate by MSOA
 
 ```{python}
 #| label: poverty-comparison
@@ -276,7 +276,7 @@ uk_poverty_cum_20 = round((merged["poverty_rateE"] > 30).sum() / len(merged),1)
 fig = plot_histograms("poverty_rateE", merged, "Leeds", n_bins=30)
 fig.show()
 ```
-- Poverty rates in Leeds have a heavier tail than the UK, with `{python} leeds_poverty_cum_20` of MSOAs having more than 20% poverty, compared to `{python} uk_poverty_cum_20` in the UK.
+- Poverty rates in Leeds have a heavier tail than the UK, with `{python} leeds_poverty_cum_20` of MSOAs having more than 30% poverty, compared to `{python} uk_poverty_cum_20` in the UK.
 
 ## Location of poverty
 
@@ -327,9 +327,11 @@ They
 
 ::: {.column width="50%"}
 <!-- add picture of UKGS -->
-![](assets/Pb_v1.png){width=80%}
+![](assets/Pb_v1_annot.png){width=80%}
 :::
 :::
+
+## Constructing soil lead by MSOA
 
 We then use this 500m grid to compute two measures:
 
@@ -345,13 +347,18 @@ We then use this 500m grid to compute two measures:
 [^1]: UK Geological Survey. Retrieved from [https://www.ukso.org/static-maps/uk-topsoil-geochemistry.html](https://www.ukso.org/static-maps/uk-topsoil-geochemistry.html)
 
 
-## Soil lead comparison
+## Soil lead comparison by MSOAs
+
 ```{python}
 #| label: soil-lead-comparison
 #| echo: false
 merged_no_soil_na = merged.dropna(subset=["soil_lead_mean"])
-fig = plot_histograms("soil_lead_mean", merged_no_soil_na, location="Leeds", other_location="UK", n_bins=40)
-fig.update_layout(title="Soil lead concentration in Leeds vs UK")
+fig = plot_histograms("idw_soil_lead_mean", merged_no_soil_na, location="Leeds", other_location="UK", n_bins=40)
+fig.update_layout(
+  title="Soil lead concentration in Leeds vs UK",
+  # change x label
+  xaxis_title="weighted average concentration (mg/kg)"
+  )
 # limit x-axis to 300
 fig.update_xaxes(range=[0, 300])
 fig.show()
@@ -380,7 +387,7 @@ fig.show()
 - We can combine the risk factors to create a hazard map
 - We can use the hazard map to identify high risk areas
   
-- This was previously done by Public Health England & Imperial College London, with our data we can supercede their work
+- This was previously done by Public Health England & Imperial College London, with our data we can add to their work
 
 ## Comparison with Public Health England {.smaller}
 

--- a/presentations/leeds.qmd
+++ b/presentations/leeds.qmd
@@ -353,7 +353,7 @@ We then use this 500m grid to compute two measures:
 #| label: soil-lead-comparison
 #| echo: false
 merged_no_soil_na = merged.dropna(subset=["soil_lead_mean"])
-fig = plot_histograms("idw_soil_lead_mean", merged_no_soil_na, location="Leeds", other_location="UK", n_bins=40)
+fig = plot_histograms("soil_lead_mean_idw", merged_no_soil_na, location="Leeds", other_location="UK", n_bins=40)
 fig.update_layout(
   title="Soil lead concentration in Leeds vs UK",
   # change x label
@@ -412,8 +412,8 @@ We have more data, at a more granular level.
 ```{python}
 #| label: risk-map
 #| echo: false
-
-fig = plot_risk_score(risk_factors, merged, "Leeds")
+risk_factors_dict = dict(zip(risk_factors, [1, 1, 1, -1, 1]))
+fig = plot_risk_score(risk_factors_dict, merged, "Leeds")
 fig.update_layout(title="Risk map for Leeds")
 fig.show()
 ```
@@ -426,19 +426,11 @@ The MSOAs with the highest risk scores are located in the **north/north-eastern 
 #| label: risk-comparison
 #| echo: false
 
-merged_w_risk = compute_risk_score(merged, risk_factors)
+merged_w_risk = compute_risk_score(merged, risk_factors_dict)
 
-# get leeds with UK-wide risk score
-leeds_w_uk_based_risk = merged_w_risk.loc[merged_w_risk["msoa_name_x"].str.contains("Leeds")]
-# compute population weighted average risk score of leeds
-leeds_risk_score_mean = round((leeds_w_uk_based_risk["risk_score"] * leeds["total_kids_2011"]).sum() / leeds["total_kids_2011"].sum(), 1)
-
-fig = plot_histograms("risk_score", merged_w_risk, "Leeds", other_location="Oxford", n_bins=10)
-fig.update_layout(title="Risk score in Leeds vs Oxford")
+fig = plot_UK_risk_comparison(merged_w_risk, locations = ["Leeds", "Nottingham", "Oxford", "Cambridge", "Manchester", "Chelsea", "Southampton"])
 fig.show()
 ```
-
-- Overall in the UK, Leeds has a (kid-count weighted) average risk score of `{python} leeds_risk_score_mean`.
 
 # Appendix
 

--- a/presentations/leeds.qmd
+++ b/presentations/leeds.qmd
@@ -9,8 +9,8 @@ format:
     slideNumber: true
     auto: true
     scrollable: true
-    # embed-resources: true
-    # self-contained-math: true
+    embed-resources: true
+    self-contained-math: true
 execute:
   enabled: true
   echo: true
@@ -268,7 +268,7 @@ fig.show()
 #| label: high-income-location
 #| echo: false
 
-fig = plot_chloropleth("median_annual_incomeE", merged, "Leeds", color_continuous_scale="rdylbu_r")
+fig = plot_chloropleth("median_annual_incomeE", merged, "Leeds", color_continuous_scale="Viridis")
 fig.show()
 ```
 - The northern outskirts are richer than the center
@@ -286,14 +286,9 @@ fig.show()
 #| cache: false
 #| echo: false
 
-# compute proportion of MSOAs that have more than 20% poverty.
-leeds_poverty_cum_20 = round((leeds["poverty_rateE"] > 30).sum() / len(leeds),1)
-uk_poverty_cum_20 = round((merged["poverty_rateE"] > 30).sum() / len(merged),1)
-
 fig = plot_histograms("poverty_rateE", merged, "Leeds", n_bins=30)
 fig.show()
 ```
-- Poverty rates in Leeds have a heavier tail than the UK, with `{python} leeds_poverty_cum_20` of MSOAs having more than 30% poverty, compared to `{python} uk_poverty_cum_20` in the UK.
 
 ## Location of poverty
 

--- a/presentations/plotting_functions.py
+++ b/presentations/plotting_functions.py
@@ -22,13 +22,16 @@ fancy_names = {
 }
 
 # plot function that shows geospatial distribution of predictor across leeds
-def plot_chloropleth(variable, df, location = "Leeds",**kwargs):
+def plot_chloropleth(variable, df, location = "Leeds", **kwargs):
     # filter for leeds
     leeds = df.loc[df["msoa_name_x"].str.contains(location)]
 
+    # hover data default
+    hover_data = kwargs.pop("hover_data", ["msoa_name_x", variable])
+
     fig = px.choropleth_mapbox(
         leeds,
-        hover_data=["msoa_name_x", variable],
+        hover_data=hover_data,
         geojson=leeds.geometry,
         locations=leeds.index,
         # center on England
@@ -179,7 +182,7 @@ def plot_heatmap(variables, df, location="Leeds"):
         z=corr_matrix,
         x=[fancy_names.get(v, v) for v in variables],
         y=[fancy_names.get(v, v) for v in variables],
-        colorscale='rdbu_r',
+        colorscale='rdbu',
         zmin=-1,
         zmax=1,
         showscale=True

--- a/presentations/plotting_functions.py
+++ b/presentations/plotting_functions.py
@@ -319,7 +319,9 @@ def plot_UK_risk_comparison(data_w_risk_score, locations = ["Leeds", "Manchester
             yref="y",
             text=location,
             showarrow=True,
-            font=dict(size=16)
+            xanchor="right",
+            font=dict(size=16),
+            textangle=70  # Rotate text
         )
 
     # update layout


### PR DESCRIPTION
- changes to YAML header to include resources (this increases file size but makes it shareable)
- minor changes to color scales/headers of existing plots

- changes to risk: the risk score now takes direction, e.g. median house price should enter the opposite direction for risk as e.g. poverty
- added calculation and comparative plotting of any selection of groups of MSOAs (e.g. LADs) along a horizontal line